### PR TITLE
Refine ELM weight updates with hidden activations

### DIFF
--- a/src/main_with_llm.py
+++ b/src/main_with_llm.py
@@ -134,10 +134,37 @@ class LLMGuidedTowerDefenseELM:
         if learning_rate is None:
             learning_rate = self.learning_rate
         
-        # Enhanced learning with LLM guidance consideration
-        prediction = self.predict(x, self.last_guidance)
+        # Normalize inputs (same as predict)
+        x_norm = []
+        for val in x:
+            if abs(val) > 1e-8:
+                x_norm.append(val / abs(val))
+            else:
+                x_norm.append(val)
+
+        # Forward pass to capture hidden activations
+        hidden = []
+        for j in range(len(self.hidden_bias)):
+            sum_val = self.hidden_bias[j]
+            for i in range(len(x_norm)):
+                sum_val += x_norm[i] * self.input_weights[i][j]
+            hidden.append(self.tanh(sum_val))
+
+        # Output layer computation
+        output = []
+        for j in range(len(self.output_weights[0])):
+            sum_val = 0
+            for i in range(len(hidden)):
+                sum_val += hidden[i] * self.output_weights[i][j]
+            output.append(sum_val)
+
+        # Apply activations
+        output[0] = self.sigmoid(output[0])
+        output[1] = self.sigmoid(output[1])
+
+        prediction = output[:]
         error = [target[i] - prediction[i] for i in range(len(target))]
-        
+
         # Adjust learning rate based on LLM guidance confidence
         if self.last_guidance:
             priority = self.last_guidance.get('priority', 'medium')
@@ -145,11 +172,25 @@ class LLMGuidedTowerDefenseELM:
                 learning_rate *= 1.5  # Learn faster for urgent situations
             elif priority == 'high':
                 learning_rate *= 1.2
-        
-        # Update output weights
+
+            guidance_influence = self._interpret_llm_guidance(self.last_guidance)
+            prediction[0] = prediction[0] * (1 - self.llm_guidance_weight) + guidance_influence['should_place'] * self.llm_guidance_weight
+            prediction[1] = prediction[1] * (1 - self.llm_guidance_weight) + guidance_influence['urgency'] * self.llm_guidance_weight
+            error = [target[i] - prediction[i] for i in range(len(target))]
+
+        # Update output weights with hidden layer contribution
+        total_change = 0.0
         for i in range(len(self.output_weights)):
             for j in range(len(self.output_weights[i])):
-                self.output_weights[i][j] += learning_rate * error[j] * 0.1
+                delta = learning_rate * error[j] * hidden[i]
+                if not math.isfinite(delta):
+                    continue
+                before = self.output_weights[i][j]
+                self.output_weights[i][j] = before + delta
+                total_change += abs(delta)
+
+        if total_change > 0:
+            print(f"[LLMGuidedTowerDefenseELM] Output weights updated (total change: {total_change:.6f})")
 
 # Simple ELM implementation without LLM guidance
 class SimpleTowerDefenseELM:
@@ -225,14 +266,50 @@ class SimpleTowerDefenseELM:
         if learning_rate is None:
             learning_rate = self.learning_rate
         
-        # Simple weight update
-        prediction = self.predict(x)
+        # Normalize inputs (same as predict)
+        x_norm = []
+        for val in x:
+            if abs(val) > 1e-8:
+                x_norm.append(val / abs(val))
+            else:
+                x_norm.append(val)
+
+        # Forward pass to capture hidden activations
+        hidden = []
+        for j in range(len(self.hidden_bias)):
+            sum_val = self.hidden_bias[j]
+            for i in range(len(x_norm)):
+                sum_val += x_norm[i] * self.input_weights[i][j]
+            hidden.append(self.tanh(sum_val))
+
+        # Output layer computation
+        output = []
+        for j in range(len(self.output_weights[0])):
+            sum_val = 0
+            for i in range(len(hidden)):
+                sum_val += hidden[i] * self.output_weights[i][j]
+            output.append(sum_val)
+
+        # Apply activations
+        output[0] = self.sigmoid(output[0])
+        output[1] = self.sigmoid(output[1])
+
+        prediction = output
         error = [target[i] - prediction[i] for i in range(len(target))]
-        
-        # Update output weights
+
+        # Update output weights with hidden layer contribution
+        total_change = 0.0
         for i in range(len(self.output_weights)):
             for j in range(len(self.output_weights[i])):
-                self.output_weights[i][j] += learning_rate * error[j] * 0.1
+                delta = learning_rate * error[j] * hidden[i]
+                if not math.isfinite(delta):
+                    continue
+                before = self.output_weights[i][j]
+                self.output_weights[i][j] = before + delta
+                total_change += abs(delta)
+
+        if total_change > 0:
+            print(f"[SimpleTowerDefenseELM] Output weights updated (total change: {total_change:.6f})")
 
 # Global model instances
 baseline_elm = SimpleTowerDefenseELM(random_state=42)

--- a/tests/test_main_with_llm_update.py
+++ b/tests/test_main_with_llm_update.py
@@ -1,0 +1,131 @@
+import sys
+import types
+import importlib
+import unittest
+
+
+# Stub external dependencies before importing the module under test
+if 'flask' not in sys.modules:
+    flask_stub = types.ModuleType('flask')
+
+    class DummyFlask:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def route(self, *args, **kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def run(self, *args, **kwargs):
+            pass
+
+    flask_stub.Flask = DummyFlask
+    flask_stub.request = types.SimpleNamespace(json=None)
+    flask_stub.jsonify = lambda *args, **kwargs: None
+    flask_stub.send_from_directory = lambda *args, **kwargs: None
+    sys.modules['flask'] = flask_stub
+
+if 'flask_cors' not in sys.modules:
+    flask_cors_stub = types.ModuleType('flask_cors')
+    flask_cors_stub.CORS = lambda *args, **kwargs: None
+    sys.modules['flask_cors'] = flask_cors_stub
+
+if 'openai' not in sys.modules:
+    openai_stub = types.ModuleType('openai')
+
+    class DummyClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    openai_stub.OpenAI = DummyClient
+    sys.modules['openai'] = openai_stub
+
+main_with_llm = importlib.import_module('src.main_with_llm')
+
+
+class ELMUpdateTests(unittest.TestCase):
+    def test_llm_guided_update_uses_hidden_activations(self):
+        model = main_with_llm.LLMGuidedTowerDefenseELM(input_size=2, hidden_size=1, output_size=2, random_state=0)
+        model.learning_rate = 0.1
+        model.input_weights = [[0.4], [-0.2]]
+        model.hidden_bias = [0.0]
+        model.output_weights = [[0.1, -0.2]]
+        x = [2.0, -3.0]
+        target = [1.0, 0.0]
+
+        before_update = [row[:] for row in model.output_weights]
+
+        # Expected hidden activation based on normalized inputs
+        x_norm = [val / abs(val) if abs(val) > 1e-8 else val for val in x]
+        hidden = []
+        for j in range(len(model.hidden_bias)):
+            sum_val = model.hidden_bias[j]
+            for i in range(len(x_norm)):
+                sum_val += x_norm[i] * model.input_weights[i][j]
+            hidden.append(model.tanh(sum_val))
+
+        # Forward pass for expected prediction
+        prediction = []
+        for j in range(len(model.output_weights[0])):
+            sum_val = 0.0
+            for i in range(len(hidden)):
+                sum_val += hidden[i] * model.output_weights[i][j]
+            prediction.append(model.sigmoid(sum_val))
+
+        error = [target[i] - prediction[i] for i in range(len(target))]
+        expected_updates = [
+            [model.learning_rate * error[j] * hidden[i] for j in range(len(model.output_weights[i]))]
+            for i in range(len(model.output_weights))
+        ]
+
+        model.update(x, target)
+
+        for i in range(len(model.output_weights)):
+            for j in range(len(model.output_weights[i])):
+                expected = before_update[i][j] + expected_updates[i][j]
+                self.assertAlmostEqual(model.output_weights[i][j], expected, places=7)
+
+    def test_simple_update_uses_hidden_activations(self):
+        model = main_with_llm.SimpleTowerDefenseELM(input_size=2, hidden_size=1, output_size=2, random_state=0)
+        model.learning_rate = 0.05
+        model.input_weights = [[-0.3], [0.25]]
+        model.hidden_bias = [0.1]
+        model.output_weights = [[0.05, 0.15]]
+        x = [-4.0, 5.0]
+        target = [0.0, 1.0]
+
+        before_update = [row[:] for row in model.output_weights]
+
+        x_norm = [val / abs(val) if abs(val) > 1e-8 else val for val in x]
+        hidden = []
+        for j in range(len(model.hidden_bias)):
+            sum_val = model.hidden_bias[j]
+            for i in range(len(x_norm)):
+                sum_val += x_norm[i] * model.input_weights[i][j]
+            hidden.append(model.tanh(sum_val))
+
+        prediction = []
+        for j in range(len(model.output_weights[0])):
+            sum_val = 0.0
+            for i in range(len(hidden)):
+                sum_val += hidden[i] * model.output_weights[i][j]
+            prediction.append(model.sigmoid(sum_val))
+
+        error = [target[i] - prediction[i] for i in range(len(target))]
+        expected_updates = [
+            [model.learning_rate * error[j] * hidden[i] for j in range(len(model.output_weights[i]))]
+            for i in range(len(model.output_weights))
+        ]
+
+        model.update(x, target)
+
+        for i in range(len(model.output_weights)):
+            for j in range(len(model.output_weights[i])):
+                expected = before_update[i][j] + expected_updates[i][j]
+                self.assertAlmostEqual(model.output_weights[i][j], expected, places=7)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- mirror the predict-time normalization and hidden-layer activation steps inside both update routines
- adjust output weight updates to account for hidden neuron contributions while preserving LLM-guided learning rate tuning and adding stability logging
- add focused unit tests that confirm both ELM variants update output weights according to their hidden activations

## Testing
- python -m unittest tests/test_main_with_llm_update.py

------
https://chatgpt.com/codex/tasks/task_e_68e0bf022b4c83279a01398e9068b332