### PR TITLE
Preserve teacher ordering in CLI argument deduplication

### DIFF
--- a/run_experiment_cli_fixed.py
+++ b/run_experiment_cli_fixed.py
@@ -106,8 +106,8 @@ class ExperimentCLI:
             if 'all' in args.teachers:
                 args.teachers = self.available_teachers
             
-            # 重複除去
-            args.teachers = list(set(args.teachers))
+            # 重複除去（順序保持）
+            args.teachers = list(dict.fromkeys(args.teachers))
             
             # 無効な教師チェック
             invalid_teachers = set(args.teachers) - set(self.available_teachers)


### PR DESCRIPTION
## Summary
- preserve the original ordering of teacher arguments when removing duplicates in the CLI validation

## Testing
- python - <<'PY'
import sys, types

# Stub dependencies to avoid heavy imports
stub_runner = types.ModuleType('run_fixed_seed_experiments')
class FixedSeedExperimentRunner:
    def __init__(self, *args, **kwargs):
        self.conditions = []
        self.seeds = []
    def run_all_conditions_sequential(self, episodes):
        return {}
    def validate_experiment_integrity(self):
        return True
stub_runner.FixedSeedExperimentRunner = FixedSeedExperimentRunner
sys.modules['run_fixed_seed_experiments'] = stub_runner

stub_real = types.ModuleType('analyze_real_data')
class RealDataAnalyzer:
    def __init__(self, *args, **kwargs):
        pass
    def run_complete_analysis(self, *args, **kwargs):
        return True
stub_real.RealDataAnalyzer = RealDataAnalyzer
sys.modules['analyze_real_data'] = stub_real

stub_llm = types.ModuleType('analyze_llm_interactions')
class LLMInteractionAnalyzer:
    def __init__(self, *args, **kwargs):
        pass
stub_llm.LLMInteractionAnalyzer = LLMInteractionAnalyzer
sys.modules['analyze_llm_interactions'] = stub_llm

stub_readme = types.ModuleType('update_readme_fixed')
class ReadmeUpdater:
    def __init__(self, *args, **kwargs):
        pass
stub_readme.ReadmeUpdater = ReadmeUpdater
sys.modules['update_readme_fixed'] = stub_readme

from run_experiment_cli_fixed import ExperimentCLI
cli = ExperimentCLI()
parser = cli.create_parser()
args = parser.parse_args(['run', '--teachers', 'all'])
cli.validate_args(args)
print('_'.join(args.teachers))
PY

------
https://chatgpt.com/codex/tasks/task_e_68e25b9cfe1c8327a96466f767567756