### PR TITLE
Update LLM adoption logging in real runner

### DIFF
--- a/run_elm_llm_real.py
+++ b/run_elm_llm_real.py
@@ -38,7 +38,14 @@ class ELMLLMHybridAgentReal(ELMTowerDefenseAgent):
         try:
             evaluation = self.llm_teacher.evaluate_state_and_recommend(env)
             self.llm_call_count += 1
-            
+
+            # ガイダンスの適用
+            final_action = self._apply_guidance(base_action, evaluation, env)
+            adopted = bool(final_action != base_action)
+
+            if adopted:
+                self.llm_adoption_count += 1
+
             # LLM介入ログ
             if self.llm_logger:
                 prompt = self.llm_teacher.get_last_prompt()
@@ -48,17 +55,11 @@ class ELMLLMHybridAgentReal(ELMTowerDefenseAgent):
                     prompt=prompt,
                     response=evaluation,
                     decision=evaluation,
-                    adopted=True
+                    adopted=adopted
                 )
-            
-            # ガイダンスの適用
-            final_action = self._apply_guidance(base_action, evaluation, env)
-            
-            if final_action != base_action:
-                self.llm_adoption_count += 1
-            
+
             return final_action, True, evaluation
-            
+
         except Exception as e:
             print(f"LLM call failed: {e}")
             # LLM失敗時はELMの行動をそのまま使用


### PR DESCRIPTION
## Summary
- ensure the adoption flag is determined after applying LLM guidance
- reuse the adoption flag for both the adoption counter and interaction logging

## Testing
- python - <<'PY' ...

------
https://chatgpt.com/codex/tasks/task_e_68e25b9ba3608327aa49e2763c13b008